### PR TITLE
fix imm of LDDW

### DIFF
--- a/data/languages/eBPF.sinc
+++ b/data/languages/eBPF.sinc
@@ -113,7 +113,7 @@ attach variables [ src dst ] [  R0  R1  R2  R3  R4  R5  R6  R7  R8  R9  R10  _  
 #bits	  	  8			 4     	 4        16              32               32               32
 # So, imm64 consists of concatination of high 8-byte imm and low 8-byte imm.
 
-:LDDW dst, concat  is imm & dst &  op_ld_st_mode=0x0 & op_ld_st_size=0x3 & op_insn_class=0x0; imm2 [ concat= (imm2 << 32) | imm; ] { dst = concat; }
+:LDDW dst, concat  is imm & dst &  op_ld_st_mode=0x0 & op_ld_st_size=0x3 & op_insn_class=0x0; imm2 [ concat= (imm2 << 32) | ((imm) & 0xFFFFFFFF); ] { dst = concat; }
 
 #BPF_LD_MAP_FD(DST, MAP_FD) -> second LDDW = pseudo LDDW insn used to refer to process-local map_fd 
 #For each instruction which needs relocation, it inject corresponding file descriptor to imm field. 


### PR DESCRIPTION
When the low 32 bits of `imm` is a negative number, the parsing result will be like below.
![image](https://user-images.githubusercontent.com/17962023/196452139-eb6e7aaa-48b6-4b67-bb7b-f999304a6c77.png)

This pr fixed it.
![image](https://user-images.githubusercontent.com/17962023/196452650-b2763534-acee-44f1-89e4-6d4714f46d58.png)
